### PR TITLE
Fix #5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,8 +131,11 @@
             <systemPropertyVariables>
               <io.netty.leakDetectionLevel>PARANOID</io.netty.leakDetectionLevel>
             </systemPropertyVariables>
-            <!-- Needs to be small enough to run in a EC2 1.7GB small instance -->
-            <argLine>-server -Xmx1200M</argLine>
+            <!--
+            Memory: Needs to be small enough to run in a EC2 1.7GB small instance
+            ArgLine: Allow using plugin injecting argLine (such as Jacoco)
+            -->
+            <argLine>${argLine} -server -Xmx1200M</argLine>
             <forkCount>1</forkCount>
             <reuseForks>true</reuseForks>
           </configuration>


### PR DESCRIPTION
Prepend the 'argLine' variable to the surefire 'argLine' parameter so any plugin can set a value.
It's basically made to get jacoco working out of the box such as with:

```
mvn clean org.jacoco:jacoco-maven-plugin:0.7.4.201502262128:prepare-agent test org.jacoco:jacoco-maven-plugin:0.7.4.201502262128:report
```