### PR TITLE
Fix #8 and Fix #9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,13 @@
     <maven.surefire.plugin.version>2.18</maven.surefire.plugin.version>
     <maven.surefire.report.plugin.version>2.18</maven.surefire.report.plugin.version>
     <maven.enforcer.plugin.version>1.3.1</maven.enforcer.plugin.version>
+    <maven.jacoco.plugin.version>0.7.5.201505241946</maven.jacoco.plugin.version>
+
+    <!--
+    surefire argLine empty by default
+    it will be populated by plugin contributing to the surefire and failsafe argument line.
+    -->
+    <surefireArgLine/>
   </properties>
 
   <build>
@@ -133,9 +140,10 @@
             </systemPropertyVariables>
             <!--
             Memory: Needs to be small enough to run in a EC2 1.7GB small instance
-            ArgLine: Allow using plugin injecting argLine (such as Jacoco)
+            ArgLine: Allow using plugin injecting argLine (such as Jacoco) - notice the @{} instead of ${} to enable
+            the late replacement.
             -->
-            <argLine>${argLine} -server -Xmx1200M</argLine>
+            <argLine>-server -Xmx1200M @{surefireArgLine}</argLine>
             <forkCount>1</forkCount>
             <reuseForks>true</reuseForks>
           </configuration>
@@ -257,6 +265,51 @@
                     </requireReleaseDeps>
                   </rules>
                   <fail>true</fail>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>coverage</id>
+
+      <!-- ease sonar integration -->
+      <properties>
+        <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
+        <sonar.jacoco.reportPath>${project.build.directory}/jacoco.exec</sonar.jacoco.reportPath>
+        <sonar.jacoco.itReportPath>${project.build.directory}/jacoco-it.exec</sonar.jacoco.itReportPath>
+      </properties>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>${maven.jacoco.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>pre-unit-test</id>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+                <configuration>
+                  <destFile>${sonar.jacoco.reportPath}</destFile>
+                  <propertyName>surefireArgLine</propertyName>
+                </configuration>
+              </execution>
+
+              <execution>
+                <id>post-unit-test</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+                <configuration>
+                  <dataFile>${sonar.jacoco.reportPath}</dataFile>
+                  <outputDirectory>${project.reporting.outputDirectory}/jacoco</outputDirectory>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
* set the surefire argLine to be empty by default (fix #8)
* add a coverage profile to compute the (unit) test coverage using jacoco