### PR TITLE
Compile Java code with parameter names in the bytecode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,9 @@
           <version>${maven.compiler.plugin.version}</version>
           <configuration>
             <optimize>true</optimize>
+            <compilerArgs>
+              <arg>-parameters</arg>
+            </compilerArgs>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
This is useful for some JVM languages, like Kotlin or Golo.

With this information in the bytecode they support named parameters calls.