### PR TITLE
Added default Implementation and Specification entries to the jar manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,10 @@
 
   <name>Vert.x Parent pom</name>
 
+  <organization>
+      <name>Eclipse</name>
+  </organization>
+
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
@@ -141,6 +145,10 @@
               <id>default-jar</id>
               <configuration>
                 <archive>
+                  <manifest>
+                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                    <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                  </manifest>
                   <!-- Generate a jar INDEX.LIST -->
                   <index>true</index>
                   <!-- Add the Maven coordinates in the manifest -->


### PR DESCRIPTION
Tested with upgrading vertx-ext-parent to this version of vertx-parent and then produced the jars for vertx-unit and vertx-bridge-common as one has its own configuration of the maven-jar-plugin and the other doesn't and they both produced the required entries.