### PR TITLE
Updates Asciidoctor version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <maven.enforcer.plugin.version>1.4.1</maven.enforcer.plugin.version>
     <maven.jacoco.plugin.version>0.7.6.201602180812</maven.jacoco.plugin.version>
     <maven.dependency.versions.check.plugin.version>2.0.2</maven.dependency.versions.check.plugin.version>
-    <maven.asciidoctor.plugin.version>1.5.6</maven.asciidoctor.plugin.version>
+    <maven.asciidoctor.plugin.version>2.1.0</maven.asciidoctor.plugin.version>
     <maven.build.helper.maven.plugin.version>3.0.0</maven.build.helper.maven.plugin.version>
 
     <!-- Override to use a different asciidoc source directory -->
@@ -122,11 +122,13 @@
           <configuration>
             <sourceDirectory>${asciidoc.dir}</sourceDirectory>
             <outputDirectory>${project.build.directory}/docs/${project.artifactId}</outputDirectory>
-            <sourceHighlighter>coderay</sourceHighlighter>
             <preserveDirectories>true</preserveDirectories>
             <relativeBaseDir>true</relativeBaseDir>
             <backend>html</backend>
             <doctype>book</doctype>
+            <attributes>
+              <source-highlighter>coderay</source-highlighter>
+            </attributes>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Signed-off-by: Emad Alblueshi <emad.albloushi@gmail.com>

Motivation:

Simply updates the version to get rid of warnings while generating docs.

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jruby.util.io.ChannelDescriptor (file:/home/user/.m2/repository/org/jruby/jruby-complete/1.7.26/jruby-complete-1.7.26.jar) to method sun.nio.ch.SelChImpl.getFD()
WARNING: Please consider reporting this to the maintainers of org.jruby.util.io.ChannelDescriptor
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```
