### PR TITLE
Fix the repo name in the `<scm>` element

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,9 +52,9 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:git@github.com:vert-x3/vert-parent.git</connection>
-    <developerConnection>scm:git:git@github.com:vert-x3/vert-parent.git</developerConnection>
-    <url>git@github.com:vert-x3/vert-parent.git</url>
+    <connection>scm:git:git@github.com:vert-x3/vertx-parent.git</connection>
+    <developerConnection>scm:git:git@github.com:vert-x3/vertx-parent.git</developerConnection>
+    <url>git@github.com:vert-x3/vertx-parent.git</url>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
The information in the `<scm>` tag is incorrect, the repo name is `vertx-parent`, not `vert-parent`.